### PR TITLE
fix(service): clear broadcast delay timeout on destroy

### DIFF
--- a/dist/Service.d.ts
+++ b/dist/Service.d.ts
@@ -27,6 +27,7 @@ export default class Service extends EventEmitter {
     subtypes: string[];
     spreaded: boolean;
     destroyed: boolean;
+    broadcastDelay: NodeJS.Timer;
     constructor(server: Server, options: ServiceOptions);
     spread(options?: {
         probe?: boolean;

--- a/dist/Service.js
+++ b/dist/Service.js
@@ -88,9 +88,10 @@ class Service extends events_1.EventEmitter {
         }
         this.spreaded = true;
         delay = Math.min(delay * Constants_1.REANNOUNCE_FACTOR, Constants_1.REANNOUNCE_MAX_MS);
-        setTimeout(async () => await this.broadcast(res, delay), delay);
+        this.broadcastDelay = setTimeout(async () => await this.broadcast(res, delay), delay);
     }
     async hide() {
+        clearTimeout(this.broadcastDelay);
         await this.sendGoodbye();
         await new Promise(resolve => setTimeout(() => resolve(), 100));
         this.spreaded = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spread-the-word",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A Bonjour / Zeroconf implementation in TypeScript",
   "repository": "https://github.com/ardean/spread-the-word",
   "bugs": "https://github.com/ardean/spread-the-word/issues",

--- a/src/Service.ts
+++ b/src/Service.ts
@@ -35,6 +35,7 @@ export default class Service extends EventEmitter {
   subtypes: string[] = [];
   spreaded: boolean = false;
   destroyed: boolean = false;
+  broadcastDelay: NodeJS.Timer;
 
   constructor(server: Server, options: ServiceOptions) {
     super();
@@ -130,10 +131,11 @@ export default class Service extends EventEmitter {
     this.spreaded = true;
 
     delay = Math.min(delay * REANNOUNCE_FACTOR, REANNOUNCE_MAX_MS);
-    setTimeout(async () => await this.broadcast(res, delay), delay);
+    this.broadcastDelay = setTimeout(async () => await this.broadcast(res, delay), delay);
   }
 
   async hide() {
+    clearTimeout(this.broadcastDelay);
     await this.sendGoodbye();
     await new Promise(resolve => setTimeout(() => resolve(), 100));
 


### PR DESCRIPTION
When destroying a service, the timeout isn't cleared and is causing the handle to stay open.