### PR TITLE
fix(listener): clear requery delay timeout on destroy

### DIFF
--- a/dist/Listener.d.ts
+++ b/dist/Listener.d.ts
@@ -18,6 +18,7 @@ export default class Listener extends EventEmitter {
     remoteServices: RemoteService[];
     typeName: string;
     wildcard: boolean;
+    requeryDelay: NodeJS.Timer;
     constructor(server: Server, options?: ListenerOptions);
     listen(): Promise<void>;
     query(): Promise<void>;

--- a/dist/Listener.js
+++ b/dist/Listener.js
@@ -67,6 +67,7 @@ class Listener extends events_1.EventEmitter {
     destroy() {
         clearTimeout(this.requeryDelay);
         this.server.removeListener("response", this.onResponse);
+        this.emit("destroy");
     }
     addRemoteService(record, txtRecord, addressRecords, res, referrer) {
         const remoteService = new RemoteService_1.default(record, txtRecord, addressRecords);

--- a/dist/Listener.js
+++ b/dist/Listener.js
@@ -62,9 +62,10 @@ class Listener extends events_1.EventEmitter {
     async requery(delay = 1000) {
         await this.query();
         delay = Math.min(delay * Constants_1.REQUERY_FACTOR, Constants_1.REQUERY_MAX_MS);
-        setTimeout(async () => await this.requery(delay), delay);
+        this.requeryDelay = setTimeout(async () => await this.requery(delay), delay);
     }
     destroy() {
+        clearTimeout(this.requeryDelay);
         this.server.removeListener("response", this.onResponse);
     }
     addRemoteService(record, txtRecord, addressRecords, res, referrer) {

--- a/dist/SpreadTheWord.d.ts
+++ b/dist/SpreadTheWord.d.ts
@@ -6,7 +6,8 @@ import Listener, { ListenerOptions } from "./Listener";
 export declare type StatusType = "uninitialized" | "spreaded" | "destroyed";
 export default class SpreadTheWord extends EventEmitter {
     server: Server;
-    services: Service[];
+    servicesList: Service[];
+    listenersList: Listener[];
     status: StatusType;
     init(options?: ServerOptions): void;
     spread(options: ServiceOptions, serverOptions?: ServerOptions): Promise<Service>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spread-the-word",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A Bonjour / Zeroconf implementation in TypeScript",
   "repository": "https://github.com/ardean/spread-the-word",
   "bugs": "https://github.com/ardean/spread-the-word/issues",

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -101,6 +101,7 @@ export default class Listener extends EventEmitter {
   destroy() {
     clearTimeout(this.requeryDelay);
     this.server.removeListener("response", this.onResponse);
+    this.emit("destroy");
   }
 
   addRemoteService(record: SRV, txtRecord: TXT, addressRecords: AddressRecord[], res: Response, referrer: Referrer) {

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -26,6 +26,7 @@ export default class Listener extends EventEmitter {
   remoteServices: RemoteService[] = [];
   typeName: string;
   wildcard: boolean;
+  requeryDelay: NodeJS.Timer;
 
   constructor(server: Server, options: ListenerOptions = {}) {
     super();
@@ -65,7 +66,7 @@ export default class Listener extends EventEmitter {
     await this.query();
 
     delay = Math.min(delay * REQUERY_FACTOR, REQUERY_MAX_MS);
-    setTimeout(async () => await this.requery(delay), delay);
+    this.requeryDelay = setTimeout(async () => await this.requery(delay), delay);
   }
 
   onResponse = async (res: Response, referrer: Referrer) => {
@@ -98,6 +99,7 @@ export default class Listener extends EventEmitter {
   }
 
   destroy() {
+    clearTimeout(this.requeryDelay);
     this.server.removeListener("response", this.onResponse);
   }
 


### PR DESCRIPTION
Found another timeout not being cleared on destroy for listeners. I've also discovered that the destroy method was not called on the listener so I duplicated the service logic to clean up on `swt.destroy()`. Renamed `services` to `servicesList` to be consistent with `listenersList` (`listeners` is already used on EventEmitter).