### PR TITLE
Add better types for EventEmitter based classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ stw.on("up", (remoteService, response, referrer) => {
   if (remoteService.txt) {
     console.log("TXT found:", remoteService.txt);
   }
-});
-
-stw.on("down", (remoteService, response, referrer) => {
+}).on("down", (remoteService, response, referrer) => {
   console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is down (from ${referrer.address})`);
 });
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ $ npm i spread-the-word
 ```js
 import stw from "spread-the-word";
 
-stw
-  .on("up", (remoteService, res, referrer) => {
-    console.log(`${remoteService.name} is up! (from ${referrer.address})`);
-  })
-  .on("down", (remoteService, res, referrer) => {
-    console.log(`${remoteService.name} is down! (from ${referrer.address})`);
-  });
+stw.on("up", (remoteService, response, referrer) => {
+  console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is up (from ${referrer.address})`);
+  if (remoteService.txt) {
+    console.log("TXT found:", remoteService.txt);
+  }
+});
+
+stw.on("down", (remoteService, response, referrer) => {
+  console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is down (from ${referrer.address})`);
+});
 
 stw.listen({ type: "jsremote" });
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,9 +13,7 @@ stw.on("up", (remoteService, response, referrer) => {
   if (remoteService.txt) {
     console.log("TXT found:", remoteService.txt);
   }
-});
-
-stw.on("down", (remoteService, response, referrer) => {
+}).on("down", (remoteService, response, referrer) => {
   console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is down (from ${referrer.address})`);
 });
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-console
 
-import stw, { RemoteService, Response, Referrer } from "../src";
+import stw from "../src";
 
 stw.init({
   transportOptions: {
@@ -8,14 +8,16 @@ stw.init({
   }
 });
 
-stw
-  .on("up", (remoteService: RemoteService, res: Response, referrer: Referrer) => {
-    console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is up (from ${referrer.address})`);
-    if (remoteService.txt) console.log("TXT found:", remoteService.txt);
-  })
-  .on("down", (remoteService: RemoteService, res: Response, referrer: Referrer) => {
-    console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is down (from ${referrer.address})`);
-  });
+stw.on("up", (remoteService, response, referrer) => {
+  console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is up (from ${referrer.address})`);
+  if (remoteService.txt) {
+    console.log("TXT found:", remoteService.txt);
+  }
+});
+
+stw.on("down", (remoteService, response, referrer) => {
+  console.log(`${remoteService.name} (type: ${remoteService.type}, port: ${remoteService.port}) is down (from ${referrer.address})`);
+});
 
 stw.listen();
 

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -21,7 +21,12 @@ export interface ListenerOptions {
   subtypes?: string[];
 }
 
-export default class Listener extends EventEmitter {
+interface Listener {
+  on(event: 'up', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  on(event: 'down', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+}
+
+class Listener extends EventEmitter {
   server: Server;
   remoteServices: RemoteService[] = [];
   typeName: string;
@@ -139,3 +144,5 @@ export default class Listener extends EventEmitter {
     await this.server.transport.query(query);
   }
 }
+
+export default Listener;

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -24,6 +24,10 @@ export interface ListenerOptions {
 interface Listener {
   on(event: 'up', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
   on(event: 'down', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  on(event: 'destroy', callback: () => void): this;
+  once(event: 'up', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  once(event: 'down', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  once(event: 'destroy', callback: () => void): this;
 }
 
 class Listener extends EventEmitter {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -21,6 +21,10 @@ export interface ServerOptions {
 interface Server {
   on(event: 'response', callback: (response: Response, referrer: Referrer) => void): this;
   on(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  on(event: 'destroy', callback: () => void): this;
+  once(event: 'response', callback: (response: Response, referrer: Referrer) => void): this;
+  once(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  once(event: 'destroy', callback: () => void): this;
 }
 
 class Server extends EventEmitter {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -18,7 +18,12 @@ export interface ServerOptions {
   socketOptions?: any;
 }
 
-export default class Server extends EventEmitter {
+interface Server {
+  on(event: 'response', callback: (response: Response, referrer: Referrer) => void): this;
+  on(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+}
+
+class Server extends EventEmitter {
   transportOptions: TransportOptions;
   services: Service[] = [];
   transport: Transport;
@@ -165,3 +170,5 @@ export default class Server extends EventEmitter {
     if (index > -1) this.services.splice(index, 1);
   }
 }
+
+export default Server;

--- a/src/Service.ts
+++ b/src/Service.ts
@@ -21,7 +21,12 @@ export interface ServiceOptions {
   hostname?: string;
 }
 
-export default class Service extends EventEmitter {
+interface Service {
+  on(event: 'destroy', callback: () => void): this;
+  once(event: 'destroy', callback: () => void): this;
+}
+
+class Service extends EventEmitter {
   type: string;
   name: string;
   server: Server;
@@ -172,3 +177,5 @@ export default class Service extends EventEmitter {
     this.emit("destroy");
   }
 }
+
+export default Service;

--- a/src/SpreadTheWord.ts
+++ b/src/SpreadTheWord.ts
@@ -8,7 +8,16 @@ import Listener, { ListenerOptions } from "./Listener";
 
 export type StatusType = "uninitialized" | "spreaded" | "destroyed";
 
-export default class SpreadTheWord extends EventEmitter {
+interface SpreadTheWord {
+  on(event: 'up', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  on(event: 'down', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  on(event: 'destroy', callback: () => void): this;
+  once(event: 'up', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  once(event: 'down', callback: (remoteService: RemoteService, response: Response, referrer: Referrer) => void): this;
+  once(event: 'destroy', callback: () => void): this;
+}
+
+class SpreadTheWord extends EventEmitter {
   server: Server;
   servicesList: Service[] = [];
   listenersList: Listener[] = [];
@@ -78,3 +87,5 @@ export default class SpreadTheWord extends EventEmitter {
     this.emit("destroy");
   }
 }
+
+export default SpreadTheWord;

--- a/src/transports/LocalTransport.ts
+++ b/src/transports/LocalTransport.ts
@@ -9,7 +9,20 @@ export interface LocalTransportOptions extends TransportOptions {
   addresses: Array<{ family: string, address: string }>;
 }
 
-export default class LocalTransport extends EventEmitter implements Transport {
+interface LocalTransport {
+  on(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  on(event: 'response', callback: (response, referrer: Referrer) => void): this;
+  on(event: 'localQuery', callback: (packet, referrerObj: any) => void): this;
+  on(event: 'localResponse', callback: (packet, referrerObj: any) => void): this;
+  on(event: 'destroy', callback: () => void): this;
+  once(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  once(event: 'response', callback: (response, referrer: Referrer) => void): this;
+  once(event: 'localQuery', callback: (packet, referrerObj: any) => void): this;
+  once(event: 'localResponse', callback: (packet, referrerObj: any) => void): this;
+  once(event: 'destroy', callback: () => void): this;
+}
+
+class LocalTransport extends EventEmitter implements Transport {
   options: LocalTransportOptions;
   addresses: Array<{ family: string, address: string }> = [];
   destroyed: boolean = false;
@@ -68,3 +81,5 @@ export default class LocalTransport extends EventEmitter implements Transport {
 function toPlainObject(instance) {
   return JSON.parse(JSON.stringify(instance));
 }
+
+export default LocalTransport;

--- a/src/transports/MDNSTransport.ts
+++ b/src/transports/MDNSTransport.ts
@@ -6,7 +6,14 @@ import * as MDNSUtil from "../MDNSUtil";
 import multicastdns from "multicast-dns";
 import Transport, { TransportOptions } from "./Transport";
 
-export default class MDNSTransport extends EventEmitter implements Transport {
+interface MDNSTransport {
+  on(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  on(event: 'response', callback: (response, referrer: Referrer) => void): this;
+  once(event: 'query', callback: (query: Query, referrer: Referrer) => void): this;
+  once(event: 'response', callback: (response, referrer: Referrer) => void): this;
+}
+
+class MDNSTransport extends EventEmitter implements Transport {
   options: TransportOptions;
   destroyed: boolean = false;
   mdns: any;
@@ -66,3 +73,5 @@ export default class MDNSTransport extends EventEmitter implements Transport {
     return MDNSUtil.getExternalAddresses();
   }
 }
+
+export default MDNSTransport;

--- a/test/Server.spec.ts
+++ b/test/Server.spec.ts
@@ -19,7 +19,7 @@ const dnsType = MDNSUtil.serializeDNSName({ type, protocol: "tcp", domain: TOP_L
 const dnsName = MDNSUtil.serializeDNSName({ name, type, protocol: "tcp", domain: TOP_LEVEL_DOMAIN });
 
 describe("Server", () => {
-  describe(`server.on("respond", fn)`, () => {
+  describe(`server.on("response", fn)`, () => {
     let transport: Transport;
     let server: Server;
 


### PR DESCRIPTION
~This makes it so intellisense now works on `listener.on()`. I'd suggest following on with this and adding it to the other `EventEmitter`s this uses.~

~I'd also recommend adding `once` variations as well as the `on`.~

This should be done in the new commit, @ardean let me know if I missed anything.